### PR TITLE
Pass ownership of event to pyopencl with new "retain" keyword arg.

### DIFF
--- a/gpyfft/fft.py
+++ b/gpyfft/fft.py
@@ -9,19 +9,45 @@ GFFT = GpyFFT(debug=False)
 # precision: single, double
 
 class FFT(object):
-    def __init__(self, context, queue, input_arrays, output_arrays=None, axes = None, fast_math = False):
+    def __init__(self, context, queue, input_arrays, output_arrays=None, axes = None, fast_math = False, filledshape_in = None, filledshape_out = None, inplace = False):
+
+        """
+        Normally, output_arrays == None means this is an in-place
+        transform.  However, for in-place real-to-complex or
+        complex-to-real transforms, the user needs to specify both
+        (and they need to be views on the same data), in which case
+        you can add inplace=True to let us know that it is actually
+        in-place.
+        Also filledshape_in/out allow you to send end-padded
+        arrays (also useful for real-to-complex/complex-to-real
+        in which case one of the arrays is padded with at least one
+        extra element!)
+        """
+
         self.context = context
         self.queue = queue
 
         in_array = input_arrays[0]
+        if filledshape_in is None:
+            filledshape_in = in_array.shape
         t_strides_in, t_distance_in, t_batchsize_in, t_shape = self.calculate_transform_strides(
-            axes, in_array.shape, in_array.strides, in_array.dtype)
+            axes, filledshape_in, in_array.strides, in_array.dtype,
+            )
 
+        outdtype = None
         if output_arrays is not None:
-            t_inplace = False
+            t_inplace = inplace
             out_array = output_arrays[0]
+            if filledshape_out is None:
+                filledshape_out = out_array.shape
             t_strides_out, t_distance_out, foo, bar = self.calculate_transform_strides(
-                axes, out_array.shape, out_array.strides, out_array.dtype)
+                axes, filledshape_out, out_array.strides, out_array.dtype)
+            outdtype = out_array.dtype
+            if in_array.dtype.kind == 'c' and outdtype.kind == 'f':
+                # complex-to-real
+                t_shape = bar
+            if inplace:
+                out_array = None
         else:
             t_inplace = True
             out_array = None
@@ -30,23 +56,40 @@ class FFT(object):
         self.t_shape = t_shape
         self.batchsize = t_batchsize_in
 
+        t_layouts = [ 'COMPLEX_INTERLEAVED', 'COMPLEX_INTERLEAVED' ]
+        if in_array.dtype.kind == 'f':
+            t_layouts[0] = 'REAL'
+            t_layouts[1] = 'HERMITIAN_INTERLEAVED'
+        if outdtype is not None:
+            if outdtype.kind == 'f':
+                t_layouts[0] = 'HERMITIAN_INTERLEAVED'
+                t_layouts[1] = 'REAL'
+        t_layouts = tuple(t_layouts)
+
         plan = GFFT.create_plan(context, t_shape)
         plan.inplace = t_inplace
         plan.strides_in = t_strides_in
         plan.strides_out = t_strides_out
         plan.distances = (t_distance_in, t_distance_out)
         plan.batch_size = t_batchsize_in #assert t_batchsize_in == t_batchsize_out
-
+        plan.layouts = t_layouts
+        
         if False:
             print('axes', axes        )
             print('in_array.shape:          ', in_array.shape)
             print('in_array.strides/itemsize', tuple(s // in_array.dtype.itemsize for s in in_array.strides))
+            if out_array is not None:
+                print('out_array.shape:          ', outn_array.shape)
+                print('out_array.strides/itemsize', tuple(s // out_array.dtype.itemsize for s in out_array.strides))
             print('shape transform          ', t_shape)
-            print('t_strides                ', t_strides_in)
+            print('t_strides_in             ', t_strides_in)
             print('distance_in              ', t_distance_in)
+            print('distance_out             ', t_distance_out)
+            print('plan.distances           ', plan.distances)
             print('batchsize                ', t_batchsize_in)
             print('t_stride_out             ', t_strides_out)
             print('inplace                  ', t_inplace)
+            print('layouts                  ', t_layouts)
 
         plan.bake(self.queue)
         temp_size = plan.temp_array_size

--- a/gpyfft/gpyfftlib.pxd
+++ b/gpyfft/gpyfftlib.pxd
@@ -212,3 +212,98 @@ cdef extern from "clFFT.h":
                                       )
     
 
+    cdef enum _clErrorCodes:
+        CL_SUCCESS
+        CL_DEVICE_NOT_FOUND
+        CL_DEVICE_NOT_AVAILABLE
+        CL_COMPILER_NOT_AVAILABLE
+        CL_MEM_OBJECT_ALLOCATION_FAILURE
+        CL_OUT_OF_RESOURCES
+        CL_OUT_OF_HOST_MEMORY
+        CL_PROFILING_INFO_NOT_AVAILABLE
+        CL_MEM_COPY_OVERLAP
+        CL_IMAGE_FORMAT_MISMATCH
+        CL_IMAGE_FORMAT_NOT_SUPPORTED
+        CL_BUILD_PROGRAM_FAILURE
+        CL_MAP_FAILURE
+        CL_MISALIGNED_SUB_BUFFER_OFFSET
+        CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST
+        CL_COMPILE_PROGRAM_FAILURE
+        CL_LINKER_NOT_AVAILABLE
+        CL_LINK_PROGRAM_FAILURE
+        CL_DEVICE_PARTITION_FAILED
+        CL_KERNEL_ARG_INFO_NOT_AVAILABLE
+        CL_INVALID_VALUE
+        CL_INVALID_DEVICE_TYPE
+        CL_INVALID_PLATFORM
+        CL_INVALID_DEVICE
+        CL_INVALID_CONTEXT
+        CL_INVALID_QUEUE_PROPERTIES
+        CL_INVALID_COMMAND_QUEUE
+        CL_INVALID_HOST_PTR
+        CL_INVALID_MEM_OBJECT
+        CL_INVALID_IMAGE_FORMAT_DESCRIPTOR
+        CL_INVALID_IMAGE_SIZE
+        CL_INVALID_SAMPLER
+        CL_INVALID_BINARY
+        CL_INVALID_BUILD_OPTIONS
+        CL_INVALID_PROGRAM
+        CL_INVALID_PROGRAM_EXECUTABLE
+        CL_INVALID_KERNEL_NAME
+        CL_INVALID_KERNEL_DEFINITION
+        CL_INVALID_KERNEL
+        CL_INVALID_ARG_INDEX
+        CL_INVALID_ARG_VALUE
+        CL_INVALID_ARG_SIZE
+        CL_INVALID_KERNEL_ARGS
+        CL_INVALID_WORK_DIMENSION
+        CL_INVALID_WORK_GROUP_SIZE
+        CL_INVALID_WORK_ITEM_SIZE
+        CL_INVALID_GLOBAL_OFFSET
+        CL_INVALID_EVENT_WAIT_LIST
+        CL_INVALID_EVENT
+        CL_INVALID_OPERATION
+        CL_INVALID_GL_OBJECT
+        CL_INVALID_BUFFER_SIZE
+        CL_INVALID_MIP_LEVEL
+        CL_INVALID_GLOBAL_WORK_SIZE
+        CL_INVALID_PROPERTY
+        CL_INVALID_IMAGE_DESCRIPTOR
+        CL_INVALID_COMPILER_OPTIONS
+        CL_INVALID_LINKER_OPTIONS
+        CL_INVALID_DEVICE_PARTITION_COUNT
+        CL_INVALID_PIPE_SIZE
+        CL_INVALID_DEVICE_QUEUE
+
+    cdef enum cl_mem_flags:
+        CL_MEM_READ_WRITE 
+        CL_MEM_WRITE_ONLY 
+        CL_MEM_READ_ONLY 
+        CL_MEM_USE_HOST_PTR 
+        CL_MEM_ALLOC_HOST_PTR 
+        CL_MEM_COPY_HOST_PTR
+    cdef enum cl_buffer_create_type:
+        CL_BUFFER_CREATE_TYPE_REGION
+    cdef enum cl_mem_info:
+        CL_MEM_TYPE  
+        CL_MEM_FLAGS 
+        CL_MEM_SIZE 
+        CL_MEM_HOST_PTR 
+        CL_MEM_MAP_COUNT 
+        CL_MEM_REFERENCE_COUNT 
+        CL_MEM_CONTEXT
+    cl_mem clCreateSubBuffer(cl_mem buffer,
+                             int flags,
+                             cl_buffer_create_type buffer_create_type,
+                             const void *buffer_create_info,
+                             cl_int *errcode_ret)
+    cl_int clReleaseMemObject(cl_mem memobj)
+    cl_int clGetMemObjectInfo(cl_mem memobj,
+                              cl_mem_info param_name,
+                              size_t param_value_size,
+                              void *param_value,
+                              size_t *param_value_size_ret)
+
+cdef struct _cl_buffer_region:
+    size_t origin
+    size_t size

--- a/gpyfft/gpyfftlib.pyx
+++ b/gpyfft/gpyfftlib.pyx
@@ -352,7 +352,7 @@ cdef class Plan(object):
                 layout0 = self._map_layouts[layout0]
             if layout1 not in self._enum_layouts:
                 layout1 = self._map_layouts[layout1]
-            errcheck(clfftSetLayout(self.plan, layouts[0], layouts[1]))
+            errcheck(clfftSetLayout(self.plan, layout0, layout1))
         
     property inplace:
         """determines if the input buffers are going to be overwritten with 

--- a/gpyfft/gpyfftlib.pyx
+++ b/gpyfft/gpyfftlib.pyx
@@ -325,6 +325,19 @@ cdef class Plan(object):
             assert len(distances) == 2
             errcheck(clfftSetPlanDistance(self.plan, distances[0], distances[1]))
 
+    # set layout by string
+    _map_layouts = {
+        'COMPLEX_INTERLEAVED': CLFFT_COMPLEX_INTERLEAVED,
+        'COMPLEX_PLANAR': CLFFT_COMPLEX_PLANAR,
+        'HERMITIAN_INTERLEAVED': CLFFT_HERMITIAN_INTERLEAVED,
+        'HERMITIAN_PLANAR': CLFFT_HERMITIAN_PLANAR,
+        'REAL': CLFFT_REAL,
+        }
+    _enum_layouts = ( CLFFT_COMPLEX_INTERLEAVED,
+                      CLFFT_COMPLEX_PLANAR,
+                      CLFFT_HERMITIAN_INTERLEAVED,
+                      CLFFT_HERMITIAN_PLANAR,
+                      CLFFT_REAL )
     property layouts:
         """the expected layout of the output buffers"""        
         def __get__(self):
@@ -333,6 +346,10 @@ cdef class Plan(object):
             return (layout_in, layout_out)
         def __set__(self, tuple layouts):
             assert len(layouts) == 2
+            if layouts[0] not in self._enum_layouts:
+                layouts[0] = self._map_layouts[layouts[0]]
+            if layouts[1] not in self._enum_layouts:
+                layouts[1] = self._map_layouts[layouts[1]]
             errcheck(clfftSetLayout(self.plan, layouts[0], layouts[1]))
         
     property inplace:

--- a/gpyfft/gpyfftlib.pyx
+++ b/gpyfft/gpyfftlib.pyx
@@ -346,10 +346,12 @@ cdef class Plan(object):
             return (layout_in, layout_out)
         def __set__(self, tuple layouts):
             assert len(layouts) == 2
-            if layouts[0] not in self._enum_layouts:
-                layouts[0] = self._map_layouts[layouts[0]]
-            if layouts[1] not in self._enum_layouts:
-                layouts[1] = self._map_layouts[layouts[1]]
+            layout0 = layouts[0]
+            layout1 = layouts[1]
+            if layout0 not in self._enum_layouts:
+                layout0 = self._map_layouts[layout0]
+            if layout1 not in self._enum_layouts:
+                layout1 = self._map_layouts[layout1]
             errcheck(clfftSetLayout(self.plan, layouts[0], layouts[1]))
         
     property inplace:

--- a/gpyfft/gpyfftlib.pyx
+++ b/gpyfft/gpyfftlib.pyx
@@ -500,6 +500,8 @@ cdef class Plan(object):
                          queues, 
                          in_buffers, 
                          out_buffers = None,
+			 in_offsets = None,
+			 out_offsets = None,
                          direction_forward = True, 
                          wait_for_events = None, 
                          temp_buffer = None,
@@ -572,14 +574,35 @@ cdef class Plan(object):
                 wait_for_events_array[i] = <cl_event><voidptr_t>event.int_ptr
             wait_for_events_ = &wait_for_events_array[0]
 
+        cdef _cl_buffer_region subbufregion
+        cdef cl_ulong subbufflags
+        cdef size_t subbufsize
+        cdef cl_int subbuferror
+        cdef cl_int errval
+
         cdef cl_mem in_buffers_[2]
         if isinstance(in_buffers, cl.MemoryObjectHolder):
             in_buffers = (in_buffers,)
         n_in_buffers = len(in_buffers)
         assert n_in_buffers <= 2
+        if in_offsets is not None:
+            assert n_in_buffers == len(in_offsets)
         for i, in_buffer in enumerate(in_buffers):
             assert isinstance(in_buffer, cl.MemoryObjectHolder)
             in_buffers_[i] = <cl_mem><voidptr_t>in_buffer.int_ptr
+            if in_offsets is not None:
+                errval = clGetMemObjectInfo(in_buffers_[i], CL_MEM_FLAGS, sizeof(subbufflags), &subbufflags, NULL)
+                if errval != CL_SUCCESS:
+                    raise Exception("Error (%d) getting memory object info CL_MEM_FLAGS!" % (errval,))
+                errval = clGetMemObjectInfo(in_buffers_[i], CL_MEM_SIZE, sizeof(subbufsize), &subbufsize, NULL)
+                if errval != CL_SUCCESS:
+                    raise Exception("Error (%d) getting memory object info CL_MEM_SIZE!" % (errval,))
+                subbufregion.origin = in_offsets[i]
+                subbufregion.size = subbufsize - subbufregion.origin
+                in_buffers_[i] = clCreateSubBuffer(in_buffers_[i], subbufflags, CL_BUFFER_CREATE_TYPE_REGION, &subbufregion, &subbuferror)
+                if subbuferror != CL_SUCCESS:
+                    raise Exception("Got error! %d (subbufregion origin=%ld size=%ld)" % (subbuferror, <long>subbufregion.origin, <long>subbufregion.size))
+                
 
         cdef cl_mem out_buffers_array[2]
         cdef cl_mem* out_buffers_ = NULL
@@ -588,9 +611,23 @@ cdef class Plan(object):
                 out_buffers = (out_buffers,)
             n_out_buffers = len(out_buffers)
             assert n_out_buffers in (1,2)
+            if out_offsets is not None:
+                assert n_out_buffers == len(out_offsets)
             for i, out_buffer in enumerate(out_buffers):
                 assert isinstance(out_buffer, cl.MemoryObjectHolder)
                 out_buffers_array[i] = <cl_mem><voidptr_t>out_buffer.int_ptr
+                if out_offsets is not None:
+                    errval = clGetMemObjectInfo(out_buffers_array[i], CL_MEM_FLAGS, sizeof(subbufflags), &subbufflags, NULL)
+                    if errval != CL_SUCCESS:
+                        raise Exception("Error (%d) getting memory object info CL_MEM_FLAGS!" % (errval,))
+                    errval = clGetMemObjectInfo(out_buffers_array[i], CL_MEM_SIZE, sizeof(subbufsize), &subbufsize, NULL)
+                    if errval != CL_SUCCESS:
+                        raise Exception("Error (%d) getting memory object info CL_MEM_SIZE!" % (errval,))
+                    subbufregion.origin = out_offsets[i]
+                    subbufregion.size = subbufsize - subbufregion.origin
+                    out_buffers_array[i] = clCreateSubBuffer(out_buffers_array[i], subbufflags, CL_BUFFER_CREATE_TYPE_REGION, &subbufregion, &subbuferror)
+                    if subbuferror != CL_SUCCESS:
+                        raise Exception("Got error! %d (subbufregion origin=%ld size=%ld)" % (subbuferror, <long>subbufregion.origin, <long>subbufregion.size))
             out_buffers_ = &out_buffers_array[0]
 
         cdef cl_mem tmp_buffer_ = NULL
@@ -611,6 +648,13 @@ cdef class Plan(object):
                                           out_buffers_,
                                           tmp_buffer_))
         
+        if in_offsets is not None:
+            for i in range(n_in_buffers):
+                clReleaseMemObject(in_buffers_[i])
+        if out_offsets is not None:
+            for i in range(n_out_buffers):
+                clReleaseMemObject(out_buffers_[i])
+
         #return tuple((cl.Event.from_cl_event_as_int(<long>out_cl_events[i]) for i in range(n_queues)))
         return tuple((cl.Event.from_int_ptr(<long>out_cl_events[i], retain=False) for i in range(n_queues)))
             

--- a/gpyfft/gpyfftlib.pyx
+++ b/gpyfft/gpyfftlib.pyx
@@ -573,29 +573,29 @@ cdef class Plan(object):
             wait_for_events_ = &wait_for_events_array[0]
 
         cdef cl_mem in_buffers_[2]
-        if isinstance(in_buffers, cl.Buffer):
+        if isinstance(in_buffers, cl.MemoryObjectHolder):
             in_buffers = (in_buffers,)
         n_in_buffers = len(in_buffers)
         assert n_in_buffers <= 2
         for i, in_buffer in enumerate(in_buffers):
-            assert isinstance(in_buffer, cl.Buffer)
+            assert isinstance(in_buffer, cl.MemoryObjectHolder)
             in_buffers_[i] = <cl_mem><voidptr_t>in_buffer.int_ptr
 
         cdef cl_mem out_buffers_array[2]
         cdef cl_mem* out_buffers_ = NULL
         if out_buffers is not None:
-            if isinstance(out_buffers, cl.Buffer):
+            if isinstance(out_buffers, cl.MemoryObjectHolder):
                 out_buffers = (out_buffers,)
             n_out_buffers = len(out_buffers)
             assert n_out_buffers in (1,2)
             for i, out_buffer in enumerate(out_buffers):
-                assert isinstance(out_buffer, cl.Buffer)
+                assert isinstance(out_buffer, cl.MemoryObjectHolder)
                 out_buffers_array[i] = <cl_mem><voidptr_t>out_buffer.int_ptr
             out_buffers_ = &out_buffers_array[0]
 
         cdef cl_mem tmp_buffer_ = NULL
         if temp_buffer is not None:
-            assert isinstance(temp_buffer, cl.Buffer)
+            assert isinstance(temp_buffer, cl.MemoryObjectHolder)
             tmp_buffer_ = <cl_mem><voidptr_t>temp_buffer.int_ptr
 
         cdef cl_event out_cl_events[MAX_QUEUES]

--- a/gpyfft/gpyfftlib.pyx
+++ b/gpyfft/gpyfftlib.pyx
@@ -595,7 +595,7 @@ cdef class Plan(object):
                                           tmp_buffer_))
         
         #return tuple((cl.Event.from_cl_event_as_int(<long>out_cl_events[i]) for i in range(n_queues)))
-        return tuple((cl.Event.from_int_ptr(<long>out_cl_events[i]) for i in range(n_queues)))
+        return tuple((cl.Event.from_int_ptr(<long>out_cl_events[i], retain=False) for i in range(n_queues)))
             
         
             

--- a/gpyfft/gpyfftlib.pyx
+++ b/gpyfft/gpyfftlib.pyx
@@ -564,7 +564,7 @@ cdef class Plan(object):
         cdef cl_event wait_for_events_array[MAX_WAITFOR_EVENTS]
         cdef cl_event* wait_for_events_ = NULL
         cdef n_waitfor_events = 0
-        if wait_for_events is not None:
+        if wait_for_events is not None and len(wait_for_events) > 0:
             n_waitfor_events = len(wait_for_events)
             assert n_waitfor_events <= MAX_WAITFOR_EVENTS
             for i, event in enumerate(wait_for_events):


### PR DESCRIPTION
This is in response to a change that I expect will be released in PyOpenCL 2016.1, so maybe shouldn't be merged until that has been released.

Discussion here:
  https://github.com/pyopencl/pyopencl/issues/113

commit here: 
  https://github.com/pyopencl/pyopencl/commit/001911e5023ae13a3299745a8d4a4dea0f52dd6a

This change allows PyOpenCL to take sole responsibility for releasing an event wrapped with `from_int_ptr`.  Without this, the event retains a dangling reference and results in a memory leak.