### PR TITLE
Pass ownership of event to pyopencl with new "retain" keyword arg.

### DIFF
--- a/gpyfft/gpyfftlib.pyx
+++ b/gpyfft/gpyfftlib.pyx
@@ -595,7 +595,7 @@ cdef class Plan(object):
                                           tmp_buffer_))
         
         #return tuple((cl.Event.from_cl_event_as_int(<long>out_cl_events[i]) for i in range(n_queues)))
-        return tuple((cl.Event.from_int_ptr(<long>out_cl_events[i]) for i in range(n_queues)))
+        return tuple((cl.Event.from_int_ptr(<long>out_cl_events[i], retain=False) for i in range(n_queues)))
             
         
             


### PR DESCRIPTION
Supercedes #19.  Same original commit.

PyOpenCL has had the retain option since version 2016.1 so if you are comfortable making 2016.1 a requirement, you can merge this.