### PR TITLE
PooledBuffer and one other minor fix

### DIFF
--- a/gpyfft/fft.py
+++ b/gpyfft/fft.py
@@ -196,13 +196,23 @@ class FFT(object):
 
         # get buffer for data
         if data.offset != 0:
-            data = data._new_with_changes(data=data.base_data[data.offset:], offset=0)
+            buf = data.base_data
+            if hasattr(buf, 'buf'):
+                # PooledBuffer (probably)
+                buf = buf.buf
+            data = data._new_with_changes(data=buf[data.offset:], offset=0)
+            del buf
         data_buffer = data.base_data
 
         if result is not None:
             # get buffer for result
             if result.offset != 0:
-                result = result._new_with_changes(data=result.base_data[result.offset:], offset=0)
+                buf = result.base_data
+                if hasattr(buf, 'buf'):
+                    # PooledBuffer (probably)
+                    buf = buf.buf
+                result = result._new_with_changes(data=buf[result.offset:], offset=0)
+                del buf
             result_buffer = result.base_data
 
             events = self.plan.enqueue_transform((self.queue,), (data_buffer,), (result_buffer),

--- a/gpyfft/fft.py
+++ b/gpyfft/fft.py
@@ -25,7 +25,7 @@ class FFT(object):
             t_inplace = False
             t_strides_out, t_distance_out, t_batchsize_out, t_shape_out, foo = self.calculate_transform_strides(
                 axes, out_array)
-            if in_array.base_data is out_array.base_data:
+            if in_array.base_data is out_array.base_data and in_array.offset == out_array.offset:
                 t_inplace = True
 
             #assert t_batchsize_out == t_batchsize_in and t_shape == t_shape_out, 'input and output size does not match' #TODO: fails for real-to-complex


### PR DESCRIPTION
Another fix to allow arrays backed by PooledBuffers to be used with offsets.
Also, there's no reason someone shouldn't be able to use different slices of the same array as input and output, so also check if the offset matches to determine whether it is an in-place transform -- does not check that the two slices don't overlap in some way, a general solution to which would be complicated.