### PR TITLE
Take care of unit-sized dimensions in the middle of transformed array…

### DIFF
--- a/gpyfft/fft.py
+++ b/gpyfft/fft.py
@@ -151,8 +151,8 @@ class FFT(object):
         # remaining, non-transformed axes
         axes_notransform = np.lib.arraysetops.setdiff1d(range(ddim), axes_transform)
         
-        #sort non-transformed axes by strides
-        axes_notransform = axes_notransform[np.argsort(strides[axes_notransform])]
+        # sort non-transformed axes by strides. [::-1] takes care of unit-size dimensions in the middle of the shape.
+        axes_notransform = axes_notransform[np.argsort(strides[axes_notransform][::-1])][::-1]
         
         #print "axes_notransformed sorted", axes_notransform
         


### PR DESCRIPTION
The reason for this pull request is that if you attempt a FFT with an array shape of (1, 5, 1, 1, 512, 512) and axes=(-1,-2), it fails with a message 'data layout not supported (only single non-transformed axis allowd)' even though it should work.

This is because the unit-sized dimensions lead to an incorrect sort of the un-transformed axis, which should be fixed by this commit.