### PR TITLE
Added the possibility to set the CLFFT_ROOT outside the setup.py file…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,27 @@ system = platform.system()
 
 ## paths settings
 # Linux
+
+EXTRA_COMPILE_ARGS = []
+EXTRA_LINK_ARGS = []
+
+## paths settings
+# Linux
 if 'Linux' in system:
-    CLFFT_DIR = r'/home/gregor/devel/clFFT'
-    CLFFT_LIB_DIR = r'/usr/local/lib64'
-    CLFFT_INCL_DIRS = [os.path.join(CLFFT_DIR, 'src', 'include'), ]
+    CLFFT_DIR = os.getenv("CLFFT_ROOT") 
+    if CLFFT_DIR is None:
+        print("CLFFT_DIR not set.\n Falling back to system default.")
+        CLFFT_DIR = r'/usr/local/'
+        CLFFT_LIB_DIRS = [os.path.join(CLFFT_DIR, 'lib64'), 
+                          os.path.join(CLFFT_DIR, 'lib')]
+        CLFFT_INCL_DIRS = [os.path.join(CLFFT_DIR, 'include')]
+    else: 
+       print("Using supplied CLFFT_ROOT dir")
+    CLFFT_LIB_DIRS = [os.path.join(CLFFT_DIR, 'build', 'library'), 
+                      os.path.join(CLFFT_DIR, 'lib')]
+    CLFFT_INCL_DIRS = [os.path.join(CLFFT_DIR, 'src', 'include')]
     CL_INCL_DIRS = ['/opt/AMDAPPSDK-3.0/include']
+
 
 #Windows
 elif 'Windows' in system:


### PR DESCRIPTION
… to allow for easy installation on different Linux systems. Also fixed errors from EXTRA_COMPILE_ARGS and EXTRA_LINK_ARGS not beeing set for systems other than MacOSX.

The previous changes broke the automatic build on linux systems. To this end, the propose changes to setup.py fix the build errors and allows to externally set the CLFFT_ROOT directory. 