### PR TITLE
Fix for pip>=25.3 forcing PEP-517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 64", "numpy", "Cython"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ elif 'Windows' in system:
     CL_INCL_DIRS = [os.path.join(CL_DIR, 'include')]
     EXTRA_COMPILE_ARGS = []
     EXTRA_LINK_ARGS = []
-    
+
 # macOS
 elif 'Darwin' in system:
     CLFFT_DIR = r'/Users/gregor/Devel/clFFT'
@@ -84,7 +84,6 @@ def get_readme():
 
 
 install_requires = ["numpy", "pyopencl"]
-setup_requires = ["numpy", "cython"]
 
 
 setup(
@@ -100,5 +99,4 @@ setup(
     ext_modules=cythonize(extensions),
     package_data=package_data,
     install_requires=install_requires,
-    setup_requires=setup_requires,
     )


### PR DESCRIPTION
As a result of the most recent release of pip, `gpyfft` no longer installs properly: see https://github.com/pypa/pip/issues/6334.

This pull request introduces a minimal `pyproject.toml` to make `gpyfft` align with modern Python packaging standards. The change ensures compatibility with PEP 517 build backends.